### PR TITLE
bug fix components/models in event_info.dart import

### DIFF
--- a/lib/models/storage.dart
+++ b/lib/models/storage.dart
@@ -1,6 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
-import 'package:sign_plus/components/event_info.dart';
+import 'package:sign_plus/models/event_info.dart';
 
 final CollectionReference mainCollection =
     FirebaseFirestore.instance.collection('event');


### PR DESCRIPTION
why did you change components folder name to models?
it's ok, I don't refuse to it, just want to know the rational.
be aware to the change I suggest here, you forgot to change here the "event_info.dart path"
please confirm the change so the bug would be fixed.